### PR TITLE
feature/01-fix-cli: Fix CLI tool - make key generation work with only a DB connection

### DIFF
--- a/app/cli.go
+++ b/app/cli.go
@@ -3,10 +3,14 @@ package app
 import (
 	"notice-me-server/pkg/auth"
 	"notice-me-server/pkg/repository"
+
+	"gorm.io/gorm"
 )
 
-func (s *server) GenerateApiKeyHandler() (*auth.ApiKey, error) {
-	repo := s.getRepository(auth.RepositoryKey).(repository.Repository[auth.ApiKey])
-
+// GenerateApiKeyCLI generates an API key using only a *gorm.DB connection.
+// It creates an auth repository, generates a key, persists it, and returns it.
+// This function does not require RabbitMQ, HTTP routes, or any other server infrastructure.
+func GenerateApiKeyCLI(db *gorm.DB) (*auth.ApiKey, error) {
+	repo := repository.NewGorm[auth.ApiKey](db)
 	return auth.GenerateApiKey(repo)
 }

--- a/app/db.go
+++ b/app/db.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"notice-me-server/pkg/auth"
+	"notice-me-server/pkg/config"
 	"notice-me-server/pkg/notification"
 	"notice-me-server/pkg/repository"
 	"time"
@@ -11,42 +12,58 @@ import (
 	"gorm.io/gorm"
 )
 
-func (s *server) connectDb() {
-	var err error
+// InitDB connects to the database using the provided config, runs auto-migration,
+// and returns the *gorm.DB handle. Callers must check the error.
+func InitDB(cfg *config.Config) (*gorm.DB, error) {
+	connection := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local",
+		cfg.Db.User, cfg.Db.Pwd, cfg.Db.Host, cfg.Db.Port, cfg.Db.Name)
 
-	connection := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local", s.c.Db.User, s.c.Db.Pwd, s.c.Db.Host, s.c.Db.Port, s.c.Db.Name)
-
-	conn, err := gorm.Open(mysql.Open(connection), &gorm.Config{})
-
+	db, err := gorm.Open(mysql.Open(connection), &gorm.Config{})
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	sqlDB, _ := conn.DB()
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, err
+	}
 
 	sqlDB.SetMaxIdleConns(10)
 	sqlDB.SetMaxOpenConns(30)
 	sqlDB.SetConnMaxLifetime(5 * time.Minute)
 
-	s.db = conn
+	if err := db.AutoMigrate(&notification.Notification{}, &auth.ApiKey{}); err != nil {
+		return nil, err
+	}
 
-	err = s.db.AutoMigrate(&notification.Notification{}, &auth.ApiKey{})
+	db.Exec("ALTER DATABASE " + cfg.Db.Name + " character set utf8mb4 collate utf8mb4_unicode_ci;")
+
+	return db, nil
+}
+
+// InitRepositories creates the standard repository map (auth + notification)
+// backed by the provided *gorm.DB. This is the lightweight initialization path
+// for tools (like the CLI) that do not need the full HTTP/RabbitMQ stack.
+func InitRepositories(db *gorm.DB) map[string]interface{} {
+	repos := make(map[string]interface{})
+	repos[notification.RepositoryKey] = repository.NewGorm[notification.Notification](db)
+	repos[auth.RepositoryKey] = repository.NewGorm[auth.ApiKey](db)
+	return repos
+}
+
+func (s *server) connectDb() {
+	db, err := InitDB(s.c)
 	if err != nil {
 		panic(err)
 	}
-
-	s.db.Exec("ALTER DATABASE " + s.c.Db.Name + " character set utf8mb4 collate utf8mb4_unicode_ci;")
+	s.db = db
 }
 
 func (s *server) initialiseRepositories() {
 	if s.db == nil {
 		s.connectDb()
 	}
-
-	s.repositories = make(map[string]interface{})
-
-	s.repositories[notification.RepositoryKey] = repository.NewGorm[notification.Notification](s.db)
-	s.repositories[auth.RepositoryKey] = repository.NewGorm[auth.ApiKey](s.db)
+	s.repositories = InitRepositories(s.db)
 }
 
 func (s *server) getRepository(name string) interface{} {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,19 +1,25 @@
 package main
 
 import (
-	"github.com/en-vee/alog"
+	"fmt"
 	"notice-me-server/app"
+	"notice-me-server/pkg/config"
 )
 
 func main() {
-	s := app.NewServer()
+	cfg := config.LoadConfig()
 
-	apiKey, err := s.GenerateApiKeyHandler()
-
+	db, err := app.InitDB(cfg)
 	if err != nil {
-		alog.Error("something went wrong: %v", err)
+		fmt.Printf("Error connecting to database: %v\n", err)
 		return
 	}
 
-	alog.Info("Api key generated successfully: " + apiKey.Value)
+	apiKey, err := app.GenerateApiKeyCLI(db)
+	if err != nil {
+		fmt.Printf("Error generating API key: %v\n", err)
+		return
+	}
+
+	fmt.Println(apiKey.Value)
 }


### PR DESCRIPTION
## Summary
- Task 01: Fix CLI tool - make key generation work with only a DB connection
- Extracted `InitDB()` and `InitRepositories()` as exported standalone functions in `app/db.go`
- Replaced `GenerateApiKeyHandler()` with standalone `GenerateApiKeyCLI()` in `app/cli.go`
- Updated `cmd/cli/main.go` to use `config.LoadConfig()` → `app.InitDB(cfg)` → `app.GenerateApiKeyCLI(db)` instead of `app.NewServer()`
<!-- auto-generated by git-agent -->