### PR TITLE
Key revocation

### DIFF
--- a/app/cli.go
+++ b/app/cli.go
@@ -16,3 +16,10 @@ func GenerateApiKeyCLI(db *gorm.DB) (string, error) {
 	repo := repository.NewGorm[auth.ApiKey](db)
 	return auth.GenerateApiKey(repo)
 }
+
+// RevokeApiKeyCLI revokes an API key by its UUID using only a *gorm.DB
+// connection. It creates an auth repository and delegates to RevokeApiKey.
+func RevokeApiKeyCLI(db *gorm.DB, id string) error {
+	repo := repository.NewGorm[auth.ApiKey](db)
+	return auth.RevokeApiKey(id, repo)
+}

--- a/app/handler_test.go
+++ b/app/handler_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"notice-me-server/pkg/auth"
 	"bytes"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
@@ -220,6 +221,7 @@ func initialiseMocks() {
 
 	repositories := make(map[string]interface{})
 	notificationsRepo := repo_mock.NewRepository[notification.Notification]()
+	authRepo := repo_mock.NewRepository[auth.ApiKey]()
 
 	notificationsRepo.CreateBulk([]notification.Notification{
 		{},
@@ -228,6 +230,7 @@ func initialiseMocks() {
 	})
 
 	repositories[notification.RepositoryKey] = notificationsRepo
+	repositories[auth.RepositoryKey] = authRepo
 
 	c := &config.Config{}
 

--- a/app/middleware.go
+++ b/app/middleware.go
@@ -42,6 +42,12 @@ func (s *server) authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
+		// Check if the key has been revoked
+		if apiKeysMatch[0].RevokedAt != nil {
+			s.writeErrorResponse(w, errors.New("API key has been revoked"), http.StatusUnauthorized)
+			return
+		}
+
 		next.ServeHTTP(w, r)
 	})
 }

--- a/app/middleware_test.go
+++ b/app/middleware_test.go
@@ -1,0 +1,92 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"notice-me-server/pkg/auth"
+	"notice-me-server/pkg/config"
+	repo_mock "notice-me-server/pkg/repository/mock"
+)
+
+func TestAuthMiddlewareMissingKey(t *testing.T) {
+	s := &server{
+		repositories: make(map[string]interface{}),
+		c:            &config.Config{},
+	}
+
+	handler := s.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("Expected 401 for missing key, got %d", rr.Code)
+	}
+}
+
+func TestAuthMiddlewareActiveKey(t *testing.T) {
+	repo := repo_mock.NewRepository[auth.ApiKey]()
+	plaintext, ak := auth.NewApiKey()
+	_ = plaintext
+	_ = repo.Create(ak)
+
+	repositories := make(map[string]interface{})
+	repositories[auth.RepositoryKey] = repo
+
+	s := &server{
+		repositories: repositories,
+		c:            &config.Config{},
+	}
+
+	handler := s.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Header.Set(auth.API_KEY_HEADER, plaintext)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected 200 for active key, got %d", rr.Code)
+	}
+}
+
+func TestAuthMiddlewareRevokedKey(t *testing.T) {
+	repo := repo_mock.NewRepository[auth.ApiKey]()
+	plaintext, ak := auth.NewApiKey()
+	_ = plaintext
+	_ = repo.Create(ak)
+
+	// Revoke the key
+	err := auth.RevokeApiKey("0", repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repositories := make(map[string]interface{})
+	repositories[auth.RepositoryKey] = repo
+
+	s := &server{
+		repositories: repositories,
+		c:            &config.Config{},
+	}
+
+	handler := s.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Header.Set(auth.API_KEY_HEADER, plaintext)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("Expected 401 for revoked key, got %d", rr.Code)
+	}
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"notice-me-server/app"
 	"notice-me-server/pkg/config"
 )
@@ -15,11 +16,32 @@ func main() {
 		return
 	}
 
-	plaintext, err := app.GenerateApiKeyCLI(db)
-	if err != nil {
-		fmt.Printf("Error generating API key: %v\n", err)
+	args := os.Args[1:]
+
+	if len(args) == 0 || args[0] == "generate" {
+		plaintext, err := app.GenerateApiKeyCLI(db)
+		if err != nil {
+			fmt.Printf("Error generating API key: %v\n", err)
+			return
+		}
+		fmt.Println(plaintext)
 		return
 	}
 
-	fmt.Println(plaintext)
+	if args[0] == "revoke" {
+		if len(args) < 2 {
+			fmt.Println("Usage: cli revoke <api-key-id>")
+			return
+		}
+		err := app.RevokeApiKeyCLI(db, args[1])
+		if err != nil {
+			fmt.Printf("Error revoking API key: %v\n", err)
+			return
+		}
+		fmt.Println("API key revoked successfully")
+		return
+	}
+
+	fmt.Printf("Unknown command: %s\n", args[0])
+	fmt.Println("Usage: cli [generate|revoke <api-key-id>]")
 }

--- a/pkg/auth/entity.go
+++ b/pkg/auth/entity.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"time"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -13,9 +14,10 @@ const RepositoryKey = "auth"
 
 type ApiKey struct {
 	gorm.Model
-	ID           uuid.UUID `gorm:"type:uuid"`
+	ID           uuid.UUID  `gorm:"type:uuid"`
 	Value        string
 	RequestCount int
+	RevokedAt    *time.Time `gorm:"default:null"`
 }
 
 // HashApiKey computes the SHA-256 digest of plaintext and returns it as a
@@ -35,5 +37,6 @@ func NewApiKey() (string, *ApiKey) {
 		ID:           uuid.New(),
 		Value:        HashApiKey(rawUUID),
 		RequestCount: 0,
+		RevokedAt:    nil,
 	}
 }

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -1,6 +1,9 @@
 package auth
 
 import (
+	"errors"
+	"time"
+
 	"notice-me-server/pkg/repository"
 )
 
@@ -16,4 +19,17 @@ func GenerateApiKey(repo repository.Repository[ApiKey]) (string, error) {
 	}
 
 	return plaintext, nil
+}
+
+// RevokeApiKey marks an API key as revoked by setting its RevokedAt timestamp
+// to the current time. Returns an error if the key is not found.
+func RevokeApiKey(id string, repo repository.Repository[ApiKey]) error {
+	ak, err := repo.Find(id)
+	if err != nil {
+		return errors.New("API key not found")
+	}
+
+	now := time.Now()
+	ak.RevokedAt = &now
+	return repo.Update(ak)
 }

--- a/pkg/auth/service_test.go
+++ b/pkg/auth/service_test.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"testing"
+
+	repo_mock "notice-me-server/pkg/repository/mock"
+)
+
+func TestRevokeApiKeySuccess(t *testing.T) {
+	repo := repo_mock.NewRepository[ApiKey]()
+	plaintext, ak := NewApiKey()
+	_ = plaintext
+	_ = repo.Create(ak)
+
+	err := RevokeApiKey("0", repo)
+	if err != nil {
+		t.Errorf("RevokeApiKey failed: %v", err)
+	}
+
+	// Verify the key was revoked
+	saved, err := repo.Find("0")
+	if err != nil {
+		t.Errorf("Failed to find revoked key: %v", err)
+	}
+	if saved.RevokedAt == nil {
+		t.Errorf("Expected RevokedAt to be set after revocation")
+	}
+}
+
+func TestRevokeApiKeyNotFound(t *testing.T) {
+	repo := repo_mock.NewRepository[ApiKey]()
+
+	err := RevokeApiKey("nonexistent", repo)
+	if err == nil {
+		t.Errorf("Expected error for non-existent key, got nil")
+	}
+	if err.Error() != "API key not found" {
+		t.Errorf("Expected 'API key not found', got: %v", err)
+	}
+}
+
+func TestNewApiKeyHasNilRevokedAt(t *testing.T) {
+	_, ak := NewApiKey()
+	if ak.RevokedAt != nil {
+		t.Errorf("Expected RevokedAt to be nil for new key, got %v", ak.RevokedAt)
+	}
+}

--- a/sdd/03-key-revocation.md
+++ b/sdd/03-key-revocation.md
@@ -1,0 +1,332 @@
+# SDD: Task 03 — Key Revocation
+
+## Summary
+
+API keys currently have no way to be deactivated. Once created, they work forever. This change adds a `RevokedAt` field to the `ApiKey` entity, checks in the auth middleware whether a key has been revoked (returning 401 if so), and exports a `RevokeApiKey()` function in the auth package to mark a key as revoked via the repository. Revoked keys remain in the database (not deleted).
+
+## Files to Modify
+
+| # | File | Action | Description |
+|---|------|--------|-------------|
+| 1 | `pkg/auth/entity.go` | modify | Add `RevokedAt *time.Time` field to `ApiKey` struct |
+| 2 | `pkg/auth/service.go` | modify | Add `RevokeApiKey(id string, repo Repository[ApiKey]) error` |
+| 3 | `app/middleware.go` | modify | After successful key lookup, check `apiKey.RevokedAt`; return 401 if revoked |
+
+## Current State
+
+### 1. `pkg/auth/entity.go`
+
+```go
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const API_KEY_HEADER = "X-API-Key"
+const RepositoryKey = "auth"
+
+type ApiKey struct {
+	gorm.Model
+	ID           uuid.UUID `gorm:"type:uuid"`
+	Value        string
+	RequestCount int
+}
+
+func HashApiKey(plaintext string) string {
+	hash := sha256.Sum256([]byte(plaintext))
+	return hex.EncodeToString(hash[:])
+}
+
+func NewApiKey() (string, *ApiKey) {
+	rawUUID := uuid.New().String()
+	return rawUUID, &ApiKey{
+		ID:           uuid.New(),
+		Value:        HashApiKey(rawUUID),
+		RequestCount: 0,
+	}
+}
+```
+
+### 2. `pkg/auth/service.go`
+
+```go
+package auth
+
+import (
+	"notice-me-server/pkg/repository"
+)
+
+func GenerateApiKey(repo repository.Repository[ApiKey]) (string, error) {
+	plaintext, ak := NewApiKey()
+	err := repo.Create(ak)
+	if err != nil {
+		return "", err
+	}
+	return plaintext, nil
+}
+```
+
+### 3. `app/middleware.go`
+
+```go
+package app
+
+import (
+	"errors"
+	"net/http"
+	"notice-me-server/pkg/auth"
+	"notice-me-server/pkg/repository"
+	"github.com/en-vee/alog"
+)
+
+func (s *server) loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		alog.Info("[" + r.Method + "] " + r.RequestURI)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *server) jsonMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *server) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiKeyHeader := r.Header.Get(auth.API_KEY_HEADER)
+		if apiKeyHeader == "" {
+			s.writeErrorResponse(w, errors.New("missing "+auth.API_KEY_HEADER+" header"), http.StatusUnauthorized)
+			return
+		}
+		hashedKey := auth.HashApiKey(apiKeyHeader)
+		repo := s.getRepository(auth.RepositoryKey).(repository.Repository[auth.ApiKey])
+		apiKeysMatch, err := repo.FindBy(repository.Field{Column: "Value", Value: hashedKey})
+		if err != nil || len(apiKeysMatch) == 0 {
+			s.writeErrorResponse(w, errors.New("invalid API key"), http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+```
+
+## Detailed Changes
+
+### 1. `pkg/auth/entity.go`
+
+**Changes:**
+- Add `"time"` import
+- Add `RevokedAt *time.Time` field to `ApiKey` struct with gorm column tag
+
+**After (full file):**
+```go
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const API_KEY_HEADER = "X-API-Key"
+const RepositoryKey = "auth"
+
+type ApiKey struct {
+	gorm.Model
+	ID           uuid.UUID  `gorm:"type:uuid"`
+	Value        string
+	RequestCount int
+	RevokedAt    *time.Time `gorm:"default:null"`
+}
+
+// HashApiKey computes the SHA-256 digest of plaintext and returns it as a
+// lowercase hex-encoded string. This is a one-way function — the original
+// value cannot be recovered from the hash.
+func HashApiKey(plaintext string) string {
+	hash := sha256.Sum256([]byte(plaintext))
+	return hex.EncodeToString(hash[:])
+}
+
+// NewApiKey generates a new API key pair: a plaintext UUID that is shown to
+// the caller exactly once, and an ApiKey entity whose Value field stores the
+// SHA-256 hash of that UUID. Only the hashed entity should be persisted.
+func NewApiKey() (string, *ApiKey) {
+	rawUUID := uuid.New().String()
+	return rawUUID, &ApiKey{
+		ID:           uuid.New(),
+		Value:        HashApiKey(rawUUID),
+		RequestCount: 0,
+		RevokedAt:    nil,
+	}
+}
+```
+
+### 2. `pkg/auth/service.go`
+
+**Changes:**
+- Add `RevokeApiKey(id string, repo Repository[ApiKey]) error` function
+- The function uses `repo.Find(id)` to locate the key, sets `RevokedAt` to current time, and calls `repo.Update(ak)` to persist
+
+**After (full file):**
+```go
+package auth
+
+import (
+	"errors"
+	"time"
+
+	"notice-me-server/pkg/repository"
+)
+
+// GenerateApiKey creates a new API key, persists the hashed entity to the
+// repository, and returns the plaintext key exactly once. The plaintext is
+// irrecoverable after this function returns — only the SHA-256 hash is stored.
+func GenerateApiKey(repo repository.Repository[ApiKey]) (string, error) {
+	plaintext, ak := NewApiKey()
+	err := repo.Create(ak)
+	if err != nil {
+		return "", err
+	}
+	return plaintext, nil
+}
+
+// RevokeApiKey marks an API key as revoked by setting its RevokedAt timestamp
+// to the current time. Returns an error if the key is not found.
+func RevokeApiKey(id string, repo repository.Repository[ApiKey]) error {
+	ak, err := repo.Find(id)
+	if err != nil {
+		return errors.New("API key not found")
+	}
+
+	now := time.Now()
+	ak.RevokedAt = &now
+	return repo.Update(ak)
+}
+```
+
+### 3. `app/middleware.go`
+
+**Changes:**
+- After finding the matching API key, check if `apiKey.RevokedAt != nil`
+- If revoked, return 401 with "API key has been revoked" error
+- Use the first match from `apiKeysMatch` (the slice)
+
+**After (full file):**
+```go
+package app
+
+import (
+	"errors"
+	"net/http"
+	"notice-me-server/pkg/auth"
+	"notice-me-server/pkg/repository"
+
+	"github.com/en-vee/alog"
+)
+
+func (s *server) loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		alog.Info("[" + r.Method + "] " + r.RequestURI)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *server) jsonMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *server) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiKeyHeader := r.Header.Get(auth.API_KEY_HEADER)
+		if apiKeyHeader == "" {
+			s.writeErrorResponse(w, errors.New("missing "+auth.API_KEY_HEADER+" header"), http.StatusUnauthorized)
+			return
+		}
+
+		hashedKey := auth.HashApiKey(apiKeyHeader)
+
+		repo := s.getRepository(auth.RepositoryKey).(repository.Repository[auth.ApiKey])
+
+		apiKeysMatch, err := repo.FindBy(repository.Field{Column: "Value", Value: hashedKey})
+
+		if err != nil || len(apiKeysMatch) == 0 {
+			s.writeErrorResponse(w, errors.New("invalid API key"), http.StatusUnauthorized)
+			return
+		}
+
+		// Check if the key has been revoked
+		if apiKeysMatch[0].RevokedAt != nil {
+			s.writeErrorResponse(w, errors.New("API key has been revoked"), http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+```
+
+## Data Flow
+
+### Key Revocation
+```
+Caller → RevokeApiKey(id, repo)
+  ├─ repo.Find(id) → *ApiKey (or error)
+  ├─ ak.RevokedAt = &time.Now()
+  └─ repo.Update(ak) → persists revocation
+```
+
+### Auth Middleware (updated)
+```
+HTTP Request (X-API-Key: ...)
+  ├─ Hash header → hashedKey
+  ├─ repo.FindBy(Value=hashedKey) → []*ApiKey
+  ├─ Check: len==0? → 401 "invalid API key"
+  ├─ Check: RevokedAt != nil? → 401 "API key has been revoked"
+  └─ Pass → next.ServeHTTP()
+```
+
+## Test Plan
+
+### New test file: `pkg/auth/service_test.go`
+
+| # | Test Case | Description | Input | Expected Output |
+|---|-----------|-------------|-------|-----------------|
+| 1 | `TestRevokeApiKeySuccess` | Revoke an existing key | Mock repo with one key; call `RevokeApiKey("0", repo)` | No error; `RevokedAt` is set on the entity |
+| 2 | `TestRevokeApiKeyNotFound` | Revoke a non-existent key | Mock repo with no matching key | Returns error "API key not found" |
+| 3 | `TestGenerateApiKeyHasNilRevokedAt` | Newly generated keys have nil RevokedAt | `NewApiKey()` | Returned entity has `RevokedAt == nil` |
+
+### Tests for middleware:
+
+Add test cases in a new file or update `app/middleware_test.go`:
+| # | Test Case | Description | Expected |
+|---|-----------|-------------|----------|
+| 1 | `TestAuthMiddlewareActiveKey` | Request with valid, active key | Passes (calls next handler) |
+| 2 | `TestAuthMiddlewareRevokedKey` | Request with valid but revoked key | Returns 401 "API key has been revoked" |
+| 3 | `TestAuthMiddlewareMissingKey` | No X-API-Key header | Returns 401 "missing X-API-Key header" |
+
+## Edge Cases & Failure Modes
+
+### Revoking Already-Revoked Key
+- Calling `RevokeApiKey` twice on the same key is safe — it just updates `RevokedAt` again with the current time. No error is returned since the key exists.
+
+### Key Not Found
+- `repo.Find(id)` returns an error. `RevokeApiKey` returns `"API key not found"`.
+
+### Nil RevokedAt on New Keys
+- `NewApiKey()` explicitly sets `RevokedAt: nil`. The middleware's check `RevokedAt != nil` will not trigger for brand-new keys.
+
+### Database Migration
+- Existing keys in the DB will have `RevokedAt = NULL`. The middleware's nil check handles this correctly — they will be treated as active.
+- Schema migration: GORM's `AutoMigrate` will add the `revoked_at` column with default null.


### PR DESCRIPTION
## Summary

- Add `RevokedAt *time.Time` field to `ApiKey` entity
- Add `RevokeApiKey()` service function that sets the revocation timestamp
- Auth middleware now checks if a key has been revoked and returns 401 if so
- Tests cover: successful revocation, key not found, nil RevokedAt on new keys, active key passes middleware, revoked key rejected, missing key header