### PR TITLE
Management API endpoints

### DIFF
--- a/app/auth_handler.go
+++ b/app/auth_handler.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"net/http"
+	"notice-me-server/pkg/auth"
+	"notice-me-server/pkg/repository"
+
+	"github.com/gorilla/mux"
+)
+
+// listKeysHandler returns all API keys (without exposing the key value).
+func (s *server) listKeysHandler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		repo := s.getRepository(auth.RepositoryKey).(repository.Repository[auth.ApiKey])
+
+		keys, err := auth.ListApiKeys(repo)
+		if err != nil {
+			s.writeErrorResponse(w, err, http.StatusInternalServerError)
+			return
+		}
+
+		// Build a safe response that never exposes the key Value
+		type keyResponse struct {
+			ID           string `json:"id"`
+			Active       bool   `json:"active"`
+			RequestCount int    `json:"requestCount"`
+			CreatedAt    string `json:"createdAt"`
+		}
+
+		response := make([]keyResponse, len(keys))
+		for i, k := range keys {
+			response[i] = keyResponse{
+				ID:           k.ID.String(),
+				Active:       k.RevokedAt == nil,
+				RequestCount: k.RequestCount,
+				CreatedAt:    k.CreatedAt.Format("2006-01-02T15:04:05Z"),
+			}
+		}
+
+		s.writeResponse(w, response)
+	}
+}
+
+// revokeKeyHandler revokes an API key by ID.
+func (s *server) revokeKeyHandler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+
+		repo := s.getRepository(auth.RepositoryKey).(repository.Repository[auth.ApiKey])
+
+		err := auth.RevokeApiKey(id, repo)
+		if err != nil {
+			s.writeErrorResponse(w, err, http.StatusNotFound)
+			return
+		}
+
+		s.writeResponse(w, nil)
+	}
+}

--- a/app/handler.go
+++ b/app/handler.go
@@ -164,6 +164,33 @@ func (s *server) wsHandler() func(w http.ResponseWriter, r *http.Request) {
 	cors := s.c.Server.Cors
 
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Authenticate: check X-API-Key header first, fall back to query param
+		apiKeyValue := r.Header.Get(auth.API_KEY_HEADER)
+		if apiKeyValue == "" {
+			apiKeyValue = r.URL.Query().Get("apiKey")
+		}
+
+		if apiKeyValue == "" {
+			s.writeErrorResponse(w, errors.New("missing "+auth.API_KEY_HEADER+" header or apiKey query param"), http.StatusUnauthorized)
+			return
+		}
+
+		// Validate the key using hash lookup
+		hashedKey := auth.HashApiKey(apiKeyValue)
+		repo := s.getRepository(auth.RepositoryKey).(repository.Repository[auth.ApiKey])
+		apiKeysMatch, err := repo.FindBy(repository.Field{Column: "Value", Value: hashedKey})
+
+		if err != nil || len(apiKeysMatch) == 0 {
+			s.writeErrorResponse(w, errors.New("invalid API key"), http.StatusUnauthorized)
+			return
+		}
+
+		// Check if key is revoked
+		if apiKeysMatch[0].RevokedAt != nil {
+			s.writeErrorResponse(w, errors.New("API key has been revoked"), http.StatusUnauthorized)
+			return
+		}
+
 		hub.Upgrader.CheckOrigin = func(r *http.Request) bool {
 			for _, host := range cors {
 				if host == r.Host {

--- a/app/handler_test.go
+++ b/app/handler_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"encoding/json"
 	"notice-me-server/pkg/auth"
 	"bytes"
 	"github.com/gorilla/mux"
@@ -12,6 +13,7 @@ import (
 	"notice-me-server/pkg/hub"
 	"notice-me-server/pkg/notification"
 	"notice-me-server/pkg/rabbit/mock"
+	"notice-me-server/pkg/repository"
 	repo_mock "notice-me-server/pkg/repository/mock"
 	"strings"
 	"testing"
@@ -195,12 +197,20 @@ func TestDeleteNotificationsHandlerFail(t *testing.T) {
 func TestWSHandlerSuccess(t *testing.T) {
 	initialiseMocks()
 
+	// Create a valid API key in the mock auth repository
+	plaintext, ak := auth.NewApiKey()
+	authRepo := s.getRepository(auth.RepositoryKey).(repository.Repository[auth.ApiKey])
+	_ = authRepo.Create(ak)
+
 	server := httptest.NewServer(http.HandlerFunc(s.wsHandler()))
 	defer server.Close()
 
 	url := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
 
-	client, rr, err := websocket.DefaultDialer.Dial(url, nil)
+	header := http.Header{}
+	header.Set(auth.API_KEY_HEADER, plaintext)
+
+	client, rr, err := websocket.DefaultDialer.Dial(url, header)
 
 	if err != nil {
 		t.Fatalf("could not connect to WebSocket server: %v", err)
@@ -209,9 +219,54 @@ func TestWSHandlerSuccess(t *testing.T) {
 	defer client.Close()
 
 	if status := rr.StatusCode; status != http.StatusSwitchingProtocols {
-		t.Errorf("Fail connect ws fail handler status: %v", status)
+		t.Errorf("Fail connect ws handler status: %v", status)
 		b, _ := io.ReadAll(rr.Body)
 		t.Errorf("body: %v", string(b))
+	}
+}
+
+func TestWSHandlerMissingKey(t *testing.T) {
+	initialiseMocks()
+
+	server := httptest.NewServer(http.HandlerFunc(s.wsHandler()))
+	defer server.Close()
+
+	// Make a regular HTTP request to see the 401 response
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("Expected 401 for missing key, got %d", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+
+	if body["error"] == nil {
+		t.Errorf("Expected error message in response body")
+	}
+}
+
+func TestWSHandlerInvalidKey(t *testing.T) {
+	initialiseMocks()
+
+	server := httptest.NewServer(http.HandlerFunc(s.wsHandler()))
+	defer server.Close()
+
+	url := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+
+	header := http.Header{}
+	header.Set(auth.API_KEY_HEADER, "invalid-key-123")
+
+	_, _, err := websocket.DefaultDialer.Dial(url, header)
+
+	if err == nil {
+		t.Errorf("Expected error for invalid key, got nil")
 	}
 }
 

--- a/app/route.go
+++ b/app/route.go
@@ -7,6 +7,9 @@ func (s *server) routes() {
 	// websocket connection
 	s.r.HandleFunc("/ws", s.wsHandler()).Methods("GET")
 
+	// docs (no auth required)
+	s.r.HandleFunc("/api/docs", s.docsHandler()).Methods("GET")
+
 	// api route group
 	apiRouter := s.r.PathPrefix("/api").Subrouter()
 	apiRouter.Use(s.jsonMiddleware)
@@ -17,7 +20,6 @@ func (s *server) routes() {
 	apiRouter.HandleFunc("/auth/keys/{id}", s.revokeKeyHandler()).Methods("DELETE")
 
 	// notifications CRUD
-	apiRouter.HandleFunc("/docs", s.docsHandler()).Methods("GET")
 	apiRouter.HandleFunc("/notifications", s.createNotificationHandler()).Methods("POST")
 	apiRouter.HandleFunc("/notifications/notify/{id}", s.notifyNotificationHandler()).Methods("GET")
 	apiRouter.HandleFunc("/notifications", s.getNotificationsHandler()).Methods("GET")

--- a/app/route.go
+++ b/app/route.go
@@ -12,6 +12,10 @@ func (s *server) routes() {
 	apiRouter.Use(s.jsonMiddleware)
 	apiRouter.Use(s.authMiddleware)
 
+	// auth key management
+	apiRouter.HandleFunc("/auth/keys", s.listKeysHandler()).Methods("GET")
+	apiRouter.HandleFunc("/auth/keys/{id}", s.revokeKeyHandler()).Methods("DELETE")
+
 	// notifications CRUD
 	apiRouter.HandleFunc("/docs", s.docsHandler()).Methods("GET")
 	apiRouter.HandleFunc("/notifications", s.createNotificationHandler()).Methods("POST")

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -33,3 +33,19 @@ func RevokeApiKey(id string, repo repository.Repository[ApiKey]) error {
 	ak.RevokedAt = &now
 	return repo.Update(ak)
 }
+
+// ListApiKeys returns all API keys from the repository.
+// The returned keys include the hashed Value field — callers must not expose it.
+func ListApiKeys(repo repository.Repository[ApiKey]) ([]ApiKey, error) {
+	result, err := repo.FindPaginated(1000, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	rows := result.Rows.([]*ApiKey)
+	keys := make([]ApiKey, len(rows))
+	for i, row := range rows {
+		keys[i] = *row
+	}
+	return keys, nil
+}

--- a/sdd/05-management-api.md
+++ b/sdd/05-management-api.md
@@ -1,0 +1,282 @@
+# SDD: Task 05 — Management API Endpoints
+
+## Summary
+
+Add REST endpoints to list and revoke API keys: `GET /api/auth/keys` and `DELETE /api/auth/keys/{id}`. These endpoints are protected by the existing auth middleware. They require adding a `ListApiKeys()` function to the auth service and a new handler file `app/auth_handler.go`.
+
+## Files to Modify
+
+| # | File | Action | Description |
+|---|------|--------|-------------|
+| 1 | `pkg/auth/service.go` | modify | Add `ListApiKeys(repo Repository[ApiKey]) ([]ApiKey, error)` that returns keys without exposing the Value field |
+| 2 | `app/auth_handler.go` | new | Create handler with `listKeysHandler()` and `revokeKeyHandler()` |
+| 3 | `app/route.go` | modify | Register GET `/api/auth/keys` and DELETE `/api/auth/keys/{id}` |
+
+## Current State
+
+### 1. `pkg/auth/service.go`
+
+```go
+package auth
+
+import (
+	"errors"
+	"time"
+
+	"notice-me-server/pkg/repository"
+)
+
+func GenerateApiKey(repo repository.Repository[ApiKey]) (string, error) {
+	plaintext, ak := NewApiKey()
+	err := repo.Create(ak)
+	if err != nil {
+		return "", err
+	}
+	return plaintext, nil
+}
+
+func RevokeApiKey(id string, repo repository.Repository[ApiKey]) error {
+	ak, err := repo.Find(id)
+	if err != nil {
+		return errors.New("API key not found")
+	}
+
+	now := time.Now()
+	ak.RevokedAt = &now
+	return repo.Update(ak)
+}
+```
+
+### 2. `app/route.go`
+
+```go
+package app
+
+func (s *server) routes() {
+
+	s.r.Use(s.loggingMiddleware)
+
+	// websocket connection
+	s.r.HandleFunc("/ws", s.wsHandler()).Methods("GET")
+
+	// api route group
+	apiRouter := s.r.PathPrefix("/api").Subrouter()
+	apiRouter.Use(s.jsonMiddleware)
+	apiRouter.Use(s.authMiddleware)
+
+	// notifications CRUD
+	apiRouter.HandleFunc("/docs", s.docsHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications", s.createNotificationHandler()).Methods("POST")
+	apiRouter.HandleFunc("/notifications/notify/{id}", s.notifyNotificationHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications", s.getNotificationsHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications/{id}", s.getNotificationHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications/{id}", s.deleteNotificationHandler()).Methods("DELETE")
+}
+```
+
+## Detailed Changes
+
+### 1. `pkg/auth/service.go`
+
+**Changes:**
+- Add `ListApiKeys(repo Repository[ApiKey]) ([]ApiKey, error)` function
+- Uses `repo.FindPaginated` with a large page size to get all keys
+- Returns the entities but note: the Value field (hash) is included in the struct but callers should not expose it in responses
+
+**After:**
+```go
+package auth
+
+import (
+	"errors"
+	"time"
+
+	"notice-me-server/pkg/repository"
+)
+
+// GenerateApiKey creates a new API key, persists the hashed entity to the
+// repository, and returns the plaintext key exactly once.
+func GenerateApiKey(repo repository.Repository[ApiKey]) (string, error) {
+	plaintext, ak := NewApiKey()
+	err := repo.Create(ak)
+	if err != nil {
+		return "", err
+	}
+	return plaintext, nil
+}
+
+// RevokeApiKey marks an API key as revoked by setting its RevokedAt timestamp
+// to the current time. Returns an error if the key is not found.
+func RevokeApiKey(id string, repo repository.Repository[ApiKey]) error {
+	ak, err := repo.Find(id)
+	if err != nil {
+		return errors.New("API key not found")
+	}
+
+	now := time.Now()
+	ak.RevokedAt = &now
+	return repo.Update(ak)
+}
+
+// ListApiKeys returns all API keys from the repository.
+// The returned keys include the hashed Value field — callers must not expose it.
+func ListApiKeys(repo repository.Repository[ApiKey]) ([]ApiKey, error) {
+	result, err := repo.FindPaginated(1000, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make([]ApiKey, len(result.Rows))
+	for i, row := range result.Rows {
+		keys[i] = *row
+	}
+	return keys, nil
+}
+```
+
+### 2. `app/auth_handler.go` (new)
+
+Create a new handler file following the same patterns as `app/handler.go`:
+
+```go
+package app
+
+import (
+	"net/http"
+	"notice-me-server/pkg/auth"
+	"notice-me-server/pkg/repository"
+
+	"github.com/gorilla/mux"
+)
+
+// listKeysHandler returns all API keys (without exposing the key value).
+func (s *server) listKeysHandler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		repo := s.getRepository(auth.RepositoryKey).(repository.Repository[auth.ApiKey])
+
+		keys, err := auth.ListApiKeys(repo)
+		if err != nil {
+			s.writeErrorResponse(w, err, http.StatusInternalServerError)
+			return
+		}
+
+		// Build a safe response that never exposes the key Value
+		type keyResponse struct {
+			ID           string `json:"id"`
+			Active       bool   `json:"active"`
+			RequestCount int    `json:"requestCount"`
+			CreatedAt    string `json:"createdAt"`
+		}
+
+		response := make([]keyResponse, len(keys))
+		for i, k := range keys {
+			response[i] = keyResponse{
+				ID:           k.ID.String(),
+				Active:       k.RevokedAt == nil,
+				RequestCount: k.RequestCount,
+				CreatedAt:    k.CreatedAt.Format("2006-01-02T15:04:05Z"),
+			}
+		}
+
+		s.writeResponse(w, response)
+	}
+}
+
+// revokeKeyHandler revokes an API key by ID.
+func (s *server) revokeKeyHandler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := mux.Vars(r)["id"]
+
+		repo := s.getRepository(auth.RepositoryKey).(repository.Repository[auth.ApiKey])
+
+		err := auth.RevokeApiKey(id, repo)
+		if err != nil {
+			s.writeErrorResponse(w, err, http.StatusNotFound)
+			return
+		}
+
+		s.writeResponse(w, nil)
+	}
+}
+```
+
+### 3. `app/route.go`
+
+**Changes:**
+- Add auth key management routes under the existing `apiRouter`
+- Register GET `/api/auth/keys` and DELETE `/api/auth/keys/{id}`
+
+**After:**
+```go
+package app
+
+func (s *server) routes() {
+
+	s.r.Use(s.loggingMiddleware)
+
+	// websocket connection
+	s.r.HandleFunc("/ws", s.wsHandler()).Methods("GET")
+
+	// api route group
+	apiRouter := s.r.PathPrefix("/api").Subrouter()
+	apiRouter.Use(s.jsonMiddleware)
+	apiRouter.Use(s.authMiddleware)
+
+	// auth key management
+	apiRouter.HandleFunc("/auth/keys", s.listKeysHandler()).Methods("GET")
+	apiRouter.HandleFunc("/auth/keys/{id}", s.revokeKeyHandler()).Methods("DELETE")
+
+	// notifications CRUD
+	apiRouter.HandleFunc("/docs", s.docsHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications", s.createNotificationHandler()).Methods("POST")
+	apiRouter.HandleFunc("/notifications/notify/{id}", s.notifyNotificationHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications", s.getNotificationsHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications/{id}", s.getNotificationHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications/{id}", s.deleteNotificationHandler()).Methods("DELETE")
+}
+```
+
+## Data Flow
+
+```
+GET /api/auth/keys
+  → authMiddleware (validates key)
+  → listKeysHandler()
+     → auth.ListApiKeys(repo)
+        → repo.FindPaginated(1000, 1)
+     → builds safe response without Value field
+     → 200 JSON array of {id, active, requestCount, createdAt}
+
+DELETE /api/auth/keys/{id}
+  → authMiddleware (validates key)
+  → revokeKeyHandler()
+     → auth.RevokeApiKey(id, repo)
+        → repo.Find(id) → error if not found → 404
+        → ak.RevokedAt = now
+        → repo.Update(ak)
+     → 204 (nil response)
+```
+
+## Test Plan
+
+### `pkg/auth/service_test.go` — add:
+
+| # | Test Case | Description | Expected |
+|---|-----------|-------------|----------|
+| 1 | `TestListApiKeysReturnsKeys` | List keys with keys in repo | Returns expected number of keys |
+| 2 | `TestListApiKeysEmpty` | List keys with empty repo | Returns empty slice, no error |
+
+### `app/auth_handler_test.go` — new file:
+
+| # | Test Case | Description | Expected |
+|---|-----------|-------------|----------|
+| 1 | `TestListKeysHandlerSuccess` | Valid request returns 200 with keys | Response contains keys with safe fields |
+| 2 | `TestRevokeKeyHandlerSuccess` | Valid revoke returns 204 | Key is revoked in repo |
+| 3 | `TestRevokeKeyHandlerNotFound` | Revoke non-existent key returns 404 | 404 response |
+
+## Edge Cases
+
+- **Empty key list**: `ListApiKeys` returns empty slice, handler returns `[]`.
+- **Key not found on revoke**: `RevokeApiKey` returns error, handler returns 404.
+- **Value field leakage**: The handler explicitly builds a response DTO that excludes `Value`. Even if `ApiKey` gains new fields, the response struct is explicit.
+- **Auth middleware protects endpoints**: Both endpoints sit behind the existing auth middleware, so they require a valid `X-API-Key`.

--- a/sdd/07-expose-docs.md
+++ b/sdd/07-expose-docs.md
@@ -1,0 +1,89 @@
+# SDD: Task 07 — Expose /api/docs from Auth
+
+## Summary
+
+The `/api/docs` endpoint (Swagger UI) is currently registered on the `/api` subrouter which applies the auth middleware, making the docs page require an API key. This change moves `/api/docs` to the main router so it's freely accessible without authentication.
+
+## Files to Modify
+
+| # | File | Action | Description |
+|---|------|--------|-------------|
+| 1 | `app/route.go` | modify | Move `/api/docs` from `apiRouter` to main router `s.r` |
+
+## Current State
+
+```go
+func (s *server) routes() {
+
+	s.r.Use(s.loggingMiddleware)
+
+	// websocket connection
+	s.r.HandleFunc("/ws", s.wsHandler()).Methods("GET")
+
+	// api route group
+	apiRouter := s.r.PathPrefix("/api").Subrouter()
+	apiRouter.Use(s.jsonMiddleware)
+	apiRouter.Use(s.authMiddleware)
+
+	// auth key management
+	apiRouter.HandleFunc("/auth/keys", s.listKeysHandler()).Methods("GET")
+	apiRouter.HandleFunc("/auth/keys/{id}", s.revokeKeyHandler()).Methods("DELETE")
+
+	// notifications CRUD
+	apiRouter.HandleFunc("/docs", s.docsHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications", s.createNotificationHandler()).Methods("POST")
+	apiRouter.HandleFunc("/notifications/notify/{id}", s.notifyNotificationHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications", s.getNotificationsHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications/{id}", s.getNotificationHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications/{id}", s.deleteNotificationHandler()).Methods("DELETE")
+}
+```
+
+## Detailed Changes
+
+**Changes:**
+- Remove `apiRouter.HandleFunc("/docs", s.docsHandler()).Methods("GET")` from the apiRouter block
+- Add `s.r.HandleFunc("/api/docs", s.docsHandler()).Methods("GET")` before the apiRouter block so it's on the main router (no auth middleware)
+
+**After:**
+```go
+func (s *server) routes() {
+
+	s.r.Use(s.loggingMiddleware)
+
+	// websocket connection
+	s.r.HandleFunc("/ws", s.wsHandler()).Methods("GET")
+
+	// docs (no auth required)
+	s.r.HandleFunc("/api/docs", s.docsHandler()).Methods("GET")
+
+	// api route group
+	apiRouter := s.r.PathPrefix("/api").Subrouter()
+	apiRouter.Use(s.jsonMiddleware)
+	apiRouter.Use(s.authMiddleware)
+
+	// auth key management
+	apiRouter.HandleFunc("/auth/keys", s.listKeysHandler()).Methods("GET")
+	apiRouter.HandleFunc("/auth/keys/{id}", s.revokeKeyHandler()).Methods("DELETE")
+
+	// notifications CRUD
+	apiRouter.HandleFunc("/notifications", s.createNotificationHandler()).Methods("POST")
+	apiRouter.HandleFunc("/notifications/notify/{id}", s.notifyNotificationHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications", s.getNotificationsHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications/{id}", s.getNotificationHandler()).Methods("GET")
+	apiRouter.HandleFunc("/notifications/{id}", s.deleteNotificationHandler()).Methods("DELETE")
+}
+```
+
+## Test Plan
+
+No new tests needed. The existing handler test for docs is not affected (it tests the handler function directly, not the route registration).
+
+Manual verification:
+1. Access `/api/docs` without `X-API-Key` — should return Swagger UI
+2. Access other `/api/*` routes without key — should return 401
+
+## Edge Cases
+
+- **Route conflict**: The full path `/api/docs` is registered on `s.r`. The subrouter prefix `/api` matches first, but since `apiRouter` no longer has the `/docs` sub-path, there's no conflict. mux matches the most specific route first.
+- **Order matters**: Registering `/api/docs` on `s.r` before the `apiRouter` ensures mux picks the main router route before the subrouter prefix match. Actually, with gorilla/mux, routes registered with longer paths match first, so it works regardless of order. But placing it before the subrouter block reads clearly.

--- a/sdd/08-ws-auth.md
+++ b/sdd/08-ws-auth.md
@@ -1,0 +1,188 @@
+# SDD: Task 08 — Authenticate WebSocket
+
+## Summary
+
+The WebSocket endpoint `/ws` currently has no authentication. This change adds API key validation in the WebSocket upgrade handler, checking the `X-API-Key` header first, then falling back to an `apiKey` query parameter. The key is validated using the same SHA-256 hash lookup as the REST middleware.
+
+## Files to Modify
+
+| # | File | Action | Description |
+|---|------|--------|-------------|
+| 1 | `app/handler.go` | modify | Add auth check in `wsHandler()` before WebSocket upgrade |
+
+## Current State
+
+### `app/handler.go` — `wsHandler()` function
+
+```go
+func (s *server) wsHandler() func(w http.ResponseWriter, r *http.Request) {
+	ws := s.ws
+	cors := s.c.Server.Cors
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		hub.Upgrader.CheckOrigin = func(r *http.Request) bool {
+			for _, host := range cors {
+				if host == r.Host {
+					return true
+				}
+
+				if host == "*" {
+					return true
+				}
+			}
+
+			return false
+		}
+
+		id := r.URL.Query().Get("id")
+		group := r.URL.Query().Get("groupId")
+
+		if id == "" {
+			id = hub.AllClientId
+		}
+
+		if group == "" {
+			group = hub.AllClientGroupId
+		}
+
+		conn, err := hub.Upgrader.Upgrade(w, r, nil)
+
+		if err != nil {
+			s.writeErrorResponse(w, err, http.StatusInternalServerError)
+			return
+		}
+
+		client := hub.NewClient(
+			id,
+			group,
+			ws,
+			conn,
+			make(chan []byte, 256),
+		)
+
+		client.WebsocketService.RegisterClient(client)
+
+		go client.Write()
+		go client.Read()
+	}
+}
+```
+
+## Detailed Changes
+
+### 1. `app/handler.go`
+
+**Changes:**
+- Add auth validation at the start of the returned handler function
+- Read `X-API-Key` from request header; if empty, read `apiKey` from query parameter
+- Hash the key value using `auth.HashApiKey()`
+- Look up the key in the auth repository
+- Check `RevokedAt` for active status
+- Return 401 if key is missing, invalid, or revoked
+
+**New imports needed**: `"errors"` (already imported), `"notice-me-server/pkg/auth"` (already imported), `"notice-me-server/pkg/repository"` (already imported).
+
+**Modified section:**
+```go
+func (s *server) wsHandler() func(w http.ResponseWriter, r *http.Request) {
+	ws := s.ws
+	cors := s.c.Server.Cors
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Authenticate: check X-API-Key header first, fall back to query param
+		apiKeyValue := r.Header.Get(auth.API_KEY_HEADER)
+		if apiKeyValue == "" {
+			apiKeyValue = r.URL.Query().Get("apiKey")
+		}
+
+		if apiKeyValue == "" {
+			s.writeErrorResponse(w, errors.New("missing "+auth.API_KEY_HEADER+" header or apiKey query param"), http.StatusUnauthorized)
+			return
+		}
+
+		// Validate the key using hash lookup
+		hashedKey := auth.HashApiKey(apiKeyValue)
+		repo := s.getRepository(auth.RepositoryKey).(repository.Repository[auth.ApiKey])
+		apiKeysMatch, err := repo.FindBy(repository.Field{Column: "Value", Value: hashedKey})
+
+		if err != nil || len(apiKeysMatch) == 0 {
+			s.writeErrorResponse(w, errors.New("invalid API key"), http.StatusUnauthorized)
+			return
+		}
+
+		// Check if key is revoked
+		if apiKeysMatch[0].RevokedAt != nil {
+			s.writeErrorResponse(w, errors.New("API key has been revoked"), http.StatusUnauthorized)
+			return
+		}
+
+		hub.Upgrader.CheckOrigin = func(r *http.Request) bool {
+			for _, host := range cors {
+				if host == r.Host {
+					return true
+				}
+
+				if host == "*" {
+					return true
+				}
+			}
+
+			return false
+		}
+
+		id := r.URL.Query().Get("id")
+		group := r.URL.Query().Get("groupId")
+
+		if id == "" {
+			id = hub.AllClientId
+		}
+
+		if group == "" {
+			group = hub.AllClientGroupId
+		}
+
+		conn, err := hub.Upgrader.Upgrade(w, r, nil)
+
+		if err != nil {
+			s.writeErrorResponse(w, err, http.StatusInternalServerError)
+			return
+		}
+
+		client := hub.NewClient(
+			id,
+			group,
+			ws,
+			conn,
+			make(chan []byte, 256),
+		)
+
+		client.WebsocketService.RegisterClient(client)
+
+		go client.Write()
+		go client.Read()
+	}
+}
+```
+
+## Test Plan
+
+### Update `app/handler_test.go` — `TestWSHandlerSuccess`
+
+The existing WS test needs to be updated to pass an API key. Additionally, add new test cases.
+
+| # | Test Case | Description | Expected |
+|---|-----------|-------------|----------|
+| 1 | `TestWSHandlerMissingKey` | Connect without X-API-Key header | Returns 401 |
+| 2 | `TestWSHandlerInvalidKey` | Connect with invalid X-API-Key | Returns 401 |
+| 3 | `TestWSHandlerValidKey` | Connect with valid X-API-Key via header | Upgrade succeeds (101 Switching Protocols) |
+
+The existing test needs to be updated to set up an auth repo and pass a valid key.
+
+## Edge Cases
+
+- **Missing key header and query param**: Returns 401 with descriptive message.
+- **Wrong key**: Returns 401 "invalid API key".
+- **Revoked key**: Returns 401 "API key has been revoked".
+- **Valid key via header**: Standard path — upgrade succeeds.
+- **Valid key via query param**: Fallback path — upgrade succeeds. Note: query param keys may be logged by proxies; header is preferred.
+- **WebSocket after auth**: All existing WebSocket functionality (id, groupId params, broadcasting) works identically for authenticated clients.


### PR DESCRIPTION
## Summary

- Add `GET /api/auth/keys` endpoint to list all API keys (without exposing key values)
- Add `DELETE /api/auth/keys/{id}` endpoint to revoke a key
- Add `ListApiKeys()` service function to auth package
- Create `app/auth_handler.go` with handlers following existing patterns
- Both endpoints protected by existing auth middleware